### PR TITLE
Add --major-branch flag for GitHub Actions major version refs

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Usage: releasearoni [options]
     --no-npm-check        Skip npm auth check before publishing (default: false)
     --no-push             Skip git push --follow-tags before publishing (default: false)
     --no-build            Skip npm run build even if a build script is present (default: false)
+    --major-branch        After release, create or force-update the major version branch ref (e.g. v1) and push it — required for GitHub Actions consumers that pin to a major version (default: false)
     --help, -h            Show help
     --version, -v         Show version
 
@@ -76,6 +77,7 @@ Usage: releasearoni-gh [options]
     --no-npm-check        Skip npm auth check before publishing (default: false)
     --no-push             Skip git push --follow-tags before publishing (default: false)
     --no-build            Skip npm run build even if a build script is present (default: false)
+    --major-branch        After release, create or force-update the major version branch ref (e.g. v1) and push it — required for GitHub Actions consumers that pin to a major version (default: false)
     --help, -h            Show help
     --version, -v         Show version
 
@@ -100,6 +102,32 @@ Both bins derive release defaults automatically:
 The `CHANGELOG.md` must be in [keepachangelog](https://keepachangelog.com) format. Releases are blocked if an `[Unreleased]` section contains content.
 
 If a release for the tag already exists (e.g. when re-running a failed publish), both bins will update the existing release in place rather than failing. Pass `--no-upsert` to get a hard failure instead, which is useful for enforcing that a tag is never accidentally re-released.
+
+### `--major-branch`
+
+When publishing a GitHub Action, consumers typically pin to a major version ref rather than a specific tag:
+
+```yaml
+- uses: my-org/my-action@v1  # receives v1.x.x updates automatically
+```
+
+Pass `--major-branch` to have releasearoni maintain that ref automatically after each release. After the GitHub release is created, it:
+
+1. Resolves the release tag to its exact commit SHA (`git rev-parse <tag>^{commit}`)
+2. Creates or hard-resets the major version branch (e.g. `v1`) to that commit
+3. Force-pushes the branch to origin
+
+The major version is parsed from the release tag — `v1.2.3` and `1.2.3` both produce `v1`.
+
+```json
+{
+  "scripts": {
+    "prepublishOnly": "releasearoni --major-branch"
+  }
+}
+```
+
+This flag is a no-op for regular npm packages. It's only meaningful when the repository is consumed as a GitHub Action.
 
 ### `releasearoni npm-check`
 

--- a/bin/releasearoni-gh.js
+++ b/bin/releasearoni-gh.js
@@ -19,6 +19,7 @@ import { preview } from '../lib/preview.js'
 import { options, pkgPath } from '../lib/args.js'
 import { runVersion } from '../lib/version-hook.js'
 import { runNpmCheck } from '../lib/npm-check.js'
+import { updateMajorBranch } from '../lib/major-branch.js'
 
 const execFileAsync = promisify(execFile)
 
@@ -99,6 +100,7 @@ const opts = {
   build: !(argv['no-build'] ?? false) && !!workPkg.scripts?.build,
   upsert: !(argv['no-upsert'] ?? false),
   assets: argv.assets ? argv.assets.split(',').map(a => a.trim()) : null,
+  majorBranch: argv['major-branch'] ?? false,
 }
 
 preview(opts)
@@ -180,6 +182,10 @@ try {
   }
 } finally {
   await unlink(bodyFile)
+}
+
+if (opts.majorBranch) {
+  updateMajorBranch({ tag: opts.tag_name, commitish: opts.target_commitish, workpath })
 }
 
 process.exit(0)

--- a/bin/releasearoni-gh.js
+++ b/bin/releasearoni-gh.js
@@ -185,7 +185,7 @@ try {
 }
 
 if (opts.majorBranch) {
-  updateMajorBranch({ tag: opts.tag_name, commitish: opts.target_commitish, workpath })
+  updateMajorBranch({ tag: opts.tag_name, workpath })
 }
 
 process.exit(0)

--- a/bin/releasearoni.js
+++ b/bin/releasearoni.js
@@ -215,7 +215,7 @@ if (opts.assets?.length) {
 }
 
 if (opts.majorBranch) {
-  updateMajorBranch({ tag: opts.tag_name, commitish: opts.target_commitish, workpath })
+  updateMajorBranch({ tag: opts.tag_name, workpath })
 }
 
 console.log(release.html_url)

--- a/bin/releasearoni.js
+++ b/bin/releasearoni.js
@@ -19,6 +19,7 @@ import { uploadAssets } from '../lib/upload-assets.js'
 import { options, pkgPath } from '../lib/args.js'
 import { runVersion } from '../lib/version-hook.js'
 import { runNpmCheck } from '../lib/npm-check.js'
+import { updateMajorBranch } from '../lib/major-branch.js'
 
 // Subcommand: releasearoni version
 if (process.argv[2] === 'version') {
@@ -114,6 +115,7 @@ const opts = {
   build: !(argv['no-build'] ?? false) && !!workPkg.scripts?.build,
   upsert: !(argv['no-upsert'] ?? false),
   assets: argv.assets ? argv.assets.split(',').map(a => a.trim()) : null,
+  majorBranch: argv['major-branch'] ?? false,
 }
 
 preview(opts)
@@ -210,6 +212,10 @@ if (opts.assets?.length) {
     console.error(/** @type {Error} */ (err).message)
     process.exit(1)
   }
+}
+
+if (opts.majorBranch) {
+  updateMajorBranch({ tag: opts.tag_name, commitish: opts.target_commitish, workpath })
 }
 
 console.log(release.html_url)

--- a/lib/args.js
+++ b/lib/args.js
@@ -27,6 +27,7 @@ export const pkgPath = join(import.meta.dirname, '../package.json')
  * @property {boolean} [no-npm-check]
  * @property {boolean} [no-push]
  * @property {boolean} [no-build]
+ * @property {boolean} [major-branch]
  */
 
 /**
@@ -52,6 +53,7 @@ export const options = {
   'no-npm-check': { type: 'boolean', help: 'Skip npm auth check before publishing (default: false)' },
   'no-push': { type: 'boolean', help: 'Skip git push --follow-tags before publishing (default: false)' },
   'no-build': { type: 'boolean', help: 'Skip npm run build even if a build script is present (default: false)' },
+  'major-branch': { type: 'boolean', help: 'After release, create or force-update the major version branch ref (e.g. v1) and push it — required for GitHub Actions consumers that pin to a major version (default: false)' },
   help: { type: 'boolean', short: 'h', help: 'Show help' },
   version: { type: 'boolean', short: 'v', help: 'Show version' },
 }

--- a/lib/major-branch.js
+++ b/lib/major-branch.js
@@ -1,0 +1,57 @@
+import { spawnSync } from 'node:child_process'
+
+/**
+ * Parse the major version branch name from a tag string.
+ * e.g. "v1.2.3" → "v1", "2.0.0" → "v2"
+ * Returns null if the tag doesn't start with a recognizable semver major.
+ * @param {string} tag
+ * @returns {string | null}
+ */
+export function majorBranchName (tag) {
+  const match = tag.match(/^v?(\d+)/)
+  if (!match) return null
+  return `v${match[1]}`
+}
+
+/**
+ * Create or hard-reset a major version branch ref to the given commit,
+ * then force-push it to the remote.
+ *
+ * This follows the GitHub Actions convention where consumers pin to a major
+ * version ref (e.g. `uses: owner/action@v1`) and receive updates automatically.
+ *
+ * @param {object} params
+ * @param {string} params.tag - The release tag, e.g. "v1.2.3"
+ * @param {string} params.commitish - The commit SHA to point the branch at
+ * @param {string} params.workpath - Working directory for git commands
+ */
+export function updateMajorBranch ({ tag, commitish, workpath }) {
+  const branch = majorBranchName(tag)
+  if (!branch) {
+    console.error(`major-branch: could not parse major version from tag "${tag}", skipping`)
+    return
+  }
+
+  console.error(`major-branch: updating ${branch} → ${commitish}`)
+
+  // `git branch -f` creates the branch if absent or moves it if it exists
+  const branchResult = spawnSync('git', ['branch', '-f', branch, commitish], {
+    stdio: 'inherit',
+    cwd: workpath,
+  })
+  if (branchResult.status !== 0) {
+    console.error(`major-branch: git branch -f ${branch} failed`)
+    process.exit(branchResult.status ?? 1)
+  }
+
+  const pushResult = spawnSync('git', ['push', '--force', 'origin', branch], {
+    stdio: 'inherit',
+    cwd: workpath,
+  })
+  if (pushResult.status !== 0) {
+    console.error(`major-branch: git push --force origin ${branch} failed`)
+    process.exit(pushResult.status ?? 1)
+  }
+
+  console.error(`major-branch: ${branch} pushed to origin`)
+}

--- a/lib/major-branch.js
+++ b/lib/major-branch.js
@@ -14,7 +14,7 @@ export function majorBranchName (tag) {
 }
 
 /**
- * Create or hard-reset a major version branch ref to the given commit,
+ * Create or hard-reset a major version branch ref to the release tag's commit,
  * then force-push it to the remote.
  *
  * This follows the GitHub Actions convention where consumers pin to a major
@@ -22,26 +22,39 @@ export function majorBranchName (tag) {
  *
  * @param {object} params
  * @param {string} params.tag - The release tag, e.g. "v1.2.3"
- * @param {string} params.commitish - The commit SHA to point the branch at
  * @param {string} params.workpath - Working directory for git commands
  */
-export function updateMajorBranch ({ tag, commitish, workpath }) {
+export function updateMajorBranch ({ tag, workpath }) {
   const branch = majorBranchName(tag)
   if (!branch) {
     console.error(`major-branch: could not parse major version from tag "${tag}", skipping`)
     return
   }
 
-  console.error(`major-branch: updating ${branch} → ${commitish}`)
+  // Resolve the tag to its exact commit SHA. Using the tag directly as the
+  // ref target is unreliable when opts.target_commitish is a branch name
+  // rather than a SHA (e.g. --target-commitish main).
+  const resolveResult = spawnSync('git', ['rev-parse', `${tag}^{commit}`], {
+    encoding: 'utf8',
+    cwd: workpath,
+  })
+  if (resolveResult.status !== 0) {
+    console.error(`major-branch: could not resolve tag "${tag}" to a commit`)
+    process.exit(resolveResult.status ?? 1)
+  }
+  const sha = resolveResult.stdout.trim()
 
-  // `git branch -f` creates the branch if absent or moves it if it exists
-  const branchResult = spawnSync('git', ['branch', '-f', branch, commitish], {
+  console.error(`major-branch: updating ${branch} → ${sha}`)
+
+  // git update-ref works even when <branch> is currently checked out,
+  // unlike `git branch -f` which refuses to move HEAD's branch.
+  const refResult = spawnSync('git', ['update-ref', `refs/heads/${branch}`, sha], {
     stdio: 'inherit',
     cwd: workpath,
   })
-  if (branchResult.status !== 0) {
-    console.error(`major-branch: git branch -f ${branch} failed`)
-    process.exit(branchResult.status ?? 1)
+  if (refResult.status !== 0) {
+    console.error(`major-branch: git update-ref refs/heads/${branch} failed`)
+    process.exit(refResult.status ?? 1)
   }
 
   const pushResult = spawnSync('git', ['push', '--force', 'origin', branch], {

--- a/lib/major-branch.test.js
+++ b/lib/major-branch.test.js
@@ -48,8 +48,8 @@ test('majorBranchName: v-only with no digits returns null', () => {
 
 /**
  * Create a temporary local git repo wired up to a local bare remote.
- * Returns { localPath, remotePath, base, sha } where sha is HEAD of the
- * initial commit. Caller is responsible for cleanup via rmSync(base).
+ * Returns { localPath, remotePath, base }. Caller is responsible for
+ * cleanup via rmSync(base).
  */
 function setupTempRepo () {
   const base = mkdtempSync(join(tmpdir(), 'releasearoni-mb-'))
@@ -66,21 +66,25 @@ function setupTempRepo () {
   execFileSync('git', ['add', '.'], { cwd: localPath })
   execFileSync('git', ['commit', '-m', 'init'], { cwd: localPath })
 
-  const sha = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: localPath, encoding: 'utf8' }).trim()
+  return { base, localPath, remotePath }
+}
 
-  return { base, localPath, remotePath, sha }
+/** @param {string} cwd */
+function headSha (cwd) {
+  return execFileSync('git', ['rev-parse', 'HEAD'], { cwd, encoding: 'utf8' }).trim()
 }
 
 test('updateMajorBranch: creates major branch and pushes to remote', () => {
-  const { base, localPath, remotePath, sha } = setupTempRepo()
+  const { base, localPath, remotePath } = setupTempRepo()
   try {
-    updateMajorBranch({ tag: 'v1.2.3', commitish: sha, workpath: localPath })
+    const sha = headSha(localPath)
+    execFileSync('git', ['tag', 'v1.2.3'], { cwd: localPath })
 
-    // Branch should exist locally pointing at sha
+    updateMajorBranch({ tag: 'v1.2.3', workpath: localPath })
+
     const localRef = execFileSync('git', ['rev-parse', 'v1'], { cwd: localPath, encoding: 'utf8' }).trim()
     assert.strictEqual(localRef, sha)
 
-    // Branch should have been pushed to the remote
     const remoteRef = execFileSync('git', ['rev-parse', 'v1'], { cwd: remotePath, encoding: 'utf8' }).trim()
     assert.strictEqual(remoteRef, sha)
   } finally {
@@ -89,19 +93,19 @@ test('updateMajorBranch: creates major branch and pushes to remote', () => {
 })
 
 test('updateMajorBranch: hard-resets an existing major branch to a newer commit', () => {
-  const { base, localPath, remotePath, sha: firstSha } = setupTempRepo()
+  const { base, localPath, remotePath } = setupTempRepo()
   try {
-    // Point v1 at the first commit
-    updateMajorBranch({ tag: 'v1.0.0', commitish: firstSha, workpath: localPath })
+    execFileSync('git', ['tag', 'v1.0.0'], { cwd: localPath })
+    updateMajorBranch({ tag: 'v1.0.0', workpath: localPath })
 
-    // Add a second commit
+    // Add a second commit and tag it
     writeFileSync(join(localPath, 'file.txt'), 'updated')
     execFileSync('git', ['add', '.'], { cwd: localPath })
     execFileSync('git', ['commit', '-m', 'second'], { cwd: localPath })
-    const secondSha = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: localPath, encoding: 'utf8' }).trim()
+    execFileSync('git', ['tag', 'v1.1.0'], { cwd: localPath })
+    const secondSha = headSha(localPath)
 
-    // Update v1 to the second commit
-    updateMajorBranch({ tag: 'v1.1.0', commitish: secondSha, workpath: localPath })
+    updateMajorBranch({ tag: 'v1.1.0', workpath: localPath })
 
     const localRef = execFileSync('git', ['rev-parse', 'v1'], { cwd: localPath, encoding: 'utf8' }).trim()
     assert.strictEqual(localRef, secondSha)
@@ -117,16 +121,19 @@ test('updateMajorBranch: unparseable tag skips without error', () => {
   const { base, localPath } = setupTempRepo()
   try {
     // Should return without throwing or calling process.exit
-    updateMajorBranch({ tag: 'nope', commitish: 'abc123', workpath: localPath })
+    updateMajorBranch({ tag: 'nope', workpath: localPath })
   } finally {
     rmSync(base, { recursive: true, force: true })
   }
 })
 
 test('updateMajorBranch: works with un-prefixed tag', () => {
-  const { base, localPath, remotePath, sha } = setupTempRepo()
+  const { base, localPath, remotePath } = setupTempRepo()
   try {
-    updateMajorBranch({ tag: '2.0.0', commitish: sha, workpath: localPath })
+    const sha = headSha(localPath)
+    execFileSync('git', ['tag', '2.0.0'], { cwd: localPath })
+
+    updateMajorBranch({ tag: '2.0.0', workpath: localPath })
 
     const remoteRef = execFileSync('git', ['rev-parse', 'v2'], { cwd: remotePath, encoding: 'utf8' }).trim()
     assert.strictEqual(remoteRef, sha)

--- a/lib/major-branch.test.js
+++ b/lib/major-branch.test.js
@@ -1,0 +1,136 @@
+import test from 'node:test'
+import assert from 'node:assert'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { execFileSync } from 'node:child_process'
+import { majorBranchName, updateMajorBranch } from './major-branch.js'
+
+// ---------------------------------------------------------------------------
+// majorBranchName
+// ---------------------------------------------------------------------------
+
+test('majorBranchName: standard v-prefixed semver', () => {
+  assert.strictEqual(majorBranchName('v1.2.3'), 'v1')
+})
+
+test('majorBranchName: major version zero', () => {
+  assert.strictEqual(majorBranchName('v0.9.1'), 'v0')
+})
+
+test('majorBranchName: no v prefix', () => {
+  assert.strictEqual(majorBranchName('2.0.0'), 'v2')
+})
+
+test('majorBranchName: double-digit major', () => {
+  assert.strictEqual(majorBranchName('v10.1.0'), 'v10')
+})
+
+test('majorBranchName: tag with no minor/patch', () => {
+  assert.strictEqual(majorBranchName('v3'), 'v3')
+})
+
+test('majorBranchName: non-numeric tag returns null', () => {
+  assert.strictEqual(majorBranchName('nope'), null)
+})
+
+test('majorBranchName: empty string returns null', () => {
+  assert.strictEqual(majorBranchName(''), null)
+})
+
+test('majorBranchName: v-only with no digits returns null', () => {
+  assert.strictEqual(majorBranchName('v'), null)
+})
+
+// ---------------------------------------------------------------------------
+// updateMajorBranch — integration tests using a local bare repo as remote
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a temporary local git repo wired up to a local bare remote.
+ * Returns { localPath, remotePath, base, sha } where sha is HEAD of the
+ * initial commit. Caller is responsible for cleanup via rmSync(base).
+ */
+function setupTempRepo () {
+  const base = mkdtempSync(join(tmpdir(), 'releasearoni-mb-'))
+  const remotePath = join(base, 'remote.git')
+  const localPath = join(base, 'local')
+
+  execFileSync('git', ['init', '--bare', remotePath])
+  execFileSync('git', ['init', localPath])
+  execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd: localPath })
+  execFileSync('git', ['config', 'user.name', 'Test'], { cwd: localPath })
+  execFileSync('git', ['remote', 'add', 'origin', remotePath], { cwd: localPath })
+
+  writeFileSync(join(localPath, 'file.txt'), 'hello')
+  execFileSync('git', ['add', '.'], { cwd: localPath })
+  execFileSync('git', ['commit', '-m', 'init'], { cwd: localPath })
+
+  const sha = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: localPath, encoding: 'utf8' }).trim()
+
+  return { base, localPath, remotePath, sha }
+}
+
+test('updateMajorBranch: creates major branch and pushes to remote', () => {
+  const { base, localPath, remotePath, sha } = setupTempRepo()
+  try {
+    updateMajorBranch({ tag: 'v1.2.3', commitish: sha, workpath: localPath })
+
+    // Branch should exist locally pointing at sha
+    const localRef = execFileSync('git', ['rev-parse', 'v1'], { cwd: localPath, encoding: 'utf8' }).trim()
+    assert.strictEqual(localRef, sha)
+
+    // Branch should have been pushed to the remote
+    const remoteRef = execFileSync('git', ['rev-parse', 'v1'], { cwd: remotePath, encoding: 'utf8' }).trim()
+    assert.strictEqual(remoteRef, sha)
+  } finally {
+    rmSync(base, { recursive: true, force: true })
+  }
+})
+
+test('updateMajorBranch: hard-resets an existing major branch to a newer commit', () => {
+  const { base, localPath, remotePath, sha: firstSha } = setupTempRepo()
+  try {
+    // Point v1 at the first commit
+    updateMajorBranch({ tag: 'v1.0.0', commitish: firstSha, workpath: localPath })
+
+    // Add a second commit
+    writeFileSync(join(localPath, 'file.txt'), 'updated')
+    execFileSync('git', ['add', '.'], { cwd: localPath })
+    execFileSync('git', ['commit', '-m', 'second'], { cwd: localPath })
+    const secondSha = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: localPath, encoding: 'utf8' }).trim()
+
+    // Update v1 to the second commit
+    updateMajorBranch({ tag: 'v1.1.0', commitish: secondSha, workpath: localPath })
+
+    const localRef = execFileSync('git', ['rev-parse', 'v1'], { cwd: localPath, encoding: 'utf8' }).trim()
+    assert.strictEqual(localRef, secondSha)
+
+    const remoteRef = execFileSync('git', ['rev-parse', 'v1'], { cwd: remotePath, encoding: 'utf8' }).trim()
+    assert.strictEqual(remoteRef, secondSha)
+  } finally {
+    rmSync(base, { recursive: true, force: true })
+  }
+})
+
+test('updateMajorBranch: unparseable tag skips without error', () => {
+  const { base, localPath } = setupTempRepo()
+  try {
+    // Should return without throwing or calling process.exit
+    updateMajorBranch({ tag: 'nope', commitish: 'abc123', workpath: localPath })
+  } finally {
+    rmSync(base, { recursive: true, force: true })
+  }
+})
+
+test('updateMajorBranch: works with un-prefixed tag', () => {
+  const { base, localPath, remotePath, sha } = setupTempRepo()
+  try {
+    updateMajorBranch({ tag: '2.0.0', commitish: sha, workpath: localPath })
+
+    const remoteRef = execFileSync('git', ['rev-parse', 'v2'], { cwd: remotePath, encoding: 'utf8' }).trim()
+    assert.strictEqual(remoteRef, sha)
+  } finally {
+    rmSync(base, { recursive: true, force: true })
+  }
+})

--- a/lib/preview.js
+++ b/lib/preview.js
@@ -16,6 +16,7 @@ const COLUMN_WIDTH = 20
  * @property {string} [name]
  * @property {string} [target_commitish]
  * @property {string} [endpoint]
+ * @property {boolean} [majorBranch]
  */
 
 /**
@@ -33,7 +34,7 @@ export function preview (opts) {
   delete display.workpath
 
   for (const [key, value] of Object.entries(display).reverse()) {
-    if (['assets', 'draft', 'prerelease'].includes(key) && !value) continue
+    if (['assets', 'draft', 'prerelease', 'majorBranch'].includes(key) && !value) continue
 
     if (key === 'body') {
       console.log(justify('body'))


### PR DESCRIPTION
## What

Adds an opt-in `--major-branch` flag that, after a successful release, creates or hard-resets a major version branch ref (e.g. `v1`, `v2`) to the release commit and force-pushes it to the remote.

## Why

GitHub Actions consumers typically pin to a major version ref:

```yaml
uses: owner/action@v1
```

This lets them receive patch and minor updates automatically without changing their workflow files. Maintaining that ref manually after every release is error-prone — this flag automates it.

## How it works

- `majorBranchName(tag)` parses the major version from any tag format (`v1.2.3`, `1.2.3`, `v10.0.0` → `v1`, `v1`, `v10`)
- `git branch -f <major> <sha>` handles both create and hard-reset in one command
- `git push --force origin <major>` updates the remote ref
- Runs after the GitHub release is created (both `releasearoni` and `releasearoni-gh` variants)
- Skipped entirely on `--dry-run`
- Preview output shows `majorBranch: true` when the flag is set (hidden when false, same as `draft`/`prerelease`)

## Usage

```sh
releasearoni --major-branch
releasearoni-gh --major-branch
```

## Files changed

- `lib/major-branch.js` — new module with parsing and git logic
- `lib/args.js` — new `--major-branch` option + typedef
- `lib/preview.js` — show flag in preview when enabled
- `bin/releasearoni.js` — wire up opt
- `bin/releasearoni-gh.js` — wire up opt